### PR TITLE
handle already started case

### DIFF
--- a/lib/credo_spellchecker/dictionary_server.ex
+++ b/lib/credo_spellchecker/dictionary_server.ex
@@ -11,7 +11,10 @@ defmodule CredoSpellchecker.DictionaryServer do
     do: GenServer.start_link(__MODULE__, params, name: __MODULE__)
 
   def get_dictionaries(params) do
-    {:ok, pid} = ensure_started(params)
+    {:ok, pid} =
+      params
+      |> ensure_started()
+      |> extract_pid()
 
     GenServer.call(pid, :get_dictionaries)
   end
@@ -35,5 +38,13 @@ defmodule CredoSpellchecker.DictionaryServer do
       nil -> start_link(params)
       pid -> {:ok, pid}
     end
+  end
+
+  defp extract_pid({:ok, pid}) do
+    {:ok, pid}
+  end
+
+  defp extract_pid({:error, {:already_started, pid}}) do
+    {:ok, pid}
   end
 end


### PR DESCRIPTION
Normally, I would add a failing test and then fix it. But that would've required some dependency injection I did not think was warranted here, given the context of the project code.

All tests pass, as before. And they pass with Elixir 1.16.0 on OTP 26.